### PR TITLE
Quoting pattern is dependent on the dialect.

### DIFF
--- a/lib/source/SequelizeSourceTask.js
+++ b/lib/source/SequelizeSourceTask.js
@@ -32,29 +32,27 @@ class SequelizeSourceTask extends SourceTask {
 
     poll(callback) {
 
+        const idColumn = this.incrementingColumnName || "id";
+        const quoteFunction = this.sequelize.dialect.QueryGenerator.quoteIdentifier;
         const query = [
             "SELECT",
             "*",
             "FROM",
-            ":table",
+            quoteFunction(this.table, true),
             "ORDER BY",
-            ":order",
+            quoteFunction(idColumn, true),
             "LIMIT",
             ":limit",
             "OFFSET",
             ":offset"
         ];
 
-        const idColumn = this.incrementingColumnName || "id";
-
         this.sequelize.query(
             query.join(" "), {
                 type: this.sequelize.QueryTypes.SELECT,
                 replacements: {
-                    table: this.table,
                     limit: this.maxPollCount,
                     offset: this.currentOffset,
-                    order: idColumn
                 }
             }
         ).then(results => {


### PR DESCRIPTION
In the case of postgresql the single quotes added by sequelize replace
are not compatible with table names or column identifiers in the query.
Looking at other parts of the sequelize codebase the quoteIdentifier
function is the appropriate one to ensure this works across dialects and
that this is still effectively a parameterised query rather than passing user data
direct to SQL.